### PR TITLE
Fix para nuevo modal de Clarín

### DIFF
--- a/clarin.css
+++ b/clarin.css
@@ -1,0 +1,6 @@
+html {
+	overflow-y: auto !important;
+}
+.modal-pase {
+	display: none;
+}

--- a/clarin.css
+++ b/clarin.css
@@ -1,6 +1,3 @@
-html {
-	overflow-y: auto !important;
-}
 .modal-pase {
 	display: none;
 }

--- a/clarin.js
+++ b/clarin.js
@@ -1,5 +1,10 @@
-document.getElementsByTagName('html')[0].style.overflowY = ""
-var arr = document.querySelectorAll('.modalLoginPase')
-for (var i = 0; i < arr.length; i++) {
-  arr[i].remove()
-}
+var interval = setInterval(function() {
+  var arr = document.querySelectorAll('.modal-pase')
+  if (arr.length) {
+    document.getElementsByTagName('html')[0].style.overflowY = ""
+    for (var i = 0; i < arr.length; i++) {
+      arr[i].remove()
+    }
+    interval = null
+  }
+}, 100)

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "short_name": "diarios-anonimos",
 
   "description": "Evita tener que registrarte para leer los diarios Clarín y La Nación.",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": "Joaquín Vicente",
   "homepage_url": "https://github.com/wacko/diarios-anonimos",
 
@@ -16,6 +16,10 @@
 
   "content_scripts": [{
     "js": ["clarin.js"],
+    "matches": ["*://*.clarin.com/*"],
+    "run_at": "document_end"
+  }, {
+    "css": ["clarin.css"],
     "matches": ["*://*.clarin.com/*"],
     "run_at": "document_end"
   }, {


### PR DESCRIPTION
Cambiado el selector y agregado un setInterval para aplicar los cambios cuando el sitio dispara el modal.

Agregado un mini CSS para evitar el posible screen flickering causado por el setInterval.